### PR TITLE
feat: 코스 상세 페이지 조회, request 요청 로직

### DIFF
--- a/src/main/java/konkuk/travelmate/controller/CourseController.java
+++ b/src/main/java/konkuk/travelmate/controller/CourseController.java
@@ -1,0 +1,22 @@
+package konkuk.travelmate.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import static org.hibernate.query.sqm.tree.SqmNode.log;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/users/{userId}/courses")
+public class CourseController {
+
+    @GetMapping("/{courseId}")
+    private String showCourseInfo(@PathVariable Long userId, @PathVariable Long courseId) {
+        log.info("[CourseController.showCourseInfo]");
+        return "unwell_deepsearch";
+    }
+
+}

--- a/src/main/java/konkuk/travelmate/controller/RequestController.java
+++ b/src/main/java/konkuk/travelmate/controller/RequestController.java
@@ -1,0 +1,44 @@
+package konkuk.travelmate.controller;
+
+import konkuk.travelmate.domain.TravelType;
+import konkuk.travelmate.form.RequestForm;
+import konkuk.travelmate.service.RequestService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Slf4j
+@Controller
+@RequestMapping("/users/{userId}/courses/{courseId}")
+@RequiredArgsConstructor
+public class RequestController {
+
+    private final RequestService requestService;
+
+    @PostMapping("/request")
+    public String requestMatching(@PathVariable Long userId, @PathVariable Long courseId,
+                                  @RequestParam TravelType type,
+                                  @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+                                  @RequestParam("startTime") @DateTimeFormat(pattern = "HH:mm") LocalTime startTime,
+                                  @RequestParam("endDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+                                  @RequestParam("endTime") @DateTimeFormat(pattern = "HH:mm") LocalTime endTime) {
+
+        log.info("[RequestController.requestMatching]");
+
+        Timestamp startDateTime = Timestamp.valueOf(LocalDateTime.of(startDate, startTime));
+        Timestamp endDateTime = Timestamp.valueOf(LocalDateTime.of(endDate, endTime));
+
+        requestService.requestMatching(userId, courseId, new RequestForm(type, startDateTime, endDateTime));
+
+        return "redirect:/users/{userId}/courses";
+
+    }
+
+}

--- a/src/main/java/konkuk/travelmate/domain/Request.java
+++ b/src/main/java/konkuk/travelmate/domain/Request.java
@@ -36,4 +36,12 @@ public class Request {
     @JoinColumn(name = "c_id")
     private Course course;
 
+    public Request(TravelType type, RequestState state, Timestamp startTime, Timestamp endTime, User disabled, Course course) {
+        this.type = type;
+        this.state = state;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.disabled = disabled;
+        this.course = course;
+    }
 }

--- a/src/main/java/konkuk/travelmate/form/RequestForm.java
+++ b/src/main/java/konkuk/travelmate/form/RequestForm.java
@@ -1,0 +1,19 @@
+package konkuk.travelmate.form;
+
+import konkuk.travelmate.domain.TravelType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+@Getter
+@AllArgsConstructor
+public class RequestForm {
+
+    private TravelType type;
+
+    private Timestamp startTime;
+
+    private Timestamp endTime;
+
+}

--- a/src/main/java/konkuk/travelmate/repository/CourseRepository.java
+++ b/src/main/java/konkuk/travelmate/repository/CourseRepository.java
@@ -1,0 +1,14 @@
+package konkuk.travelmate.repository;
+
+import konkuk.travelmate.domain.Course;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {"health"})
+    Optional<Course> findById(Long courseId);
+}

--- a/src/main/java/konkuk/travelmate/repository/RequestRepository.java
+++ b/src/main/java/konkuk/travelmate/repository/RequestRepository.java
@@ -1,0 +1,7 @@
+package konkuk.travelmate.repository;
+
+import konkuk.travelmate.domain.Request;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequestRepository extends JpaRepository<Request, Long> {
+}

--- a/src/main/java/konkuk/travelmate/repository/UserRepository.java
+++ b/src/main/java/konkuk/travelmate/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package konkuk.travelmate.repository;
+
+import konkuk.travelmate.domain.User;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Override
+    @EntityGraph(attributePaths = {"health"})
+    Optional<User> findById(Long userId);
+}

--- a/src/main/java/konkuk/travelmate/service/RequestService.java
+++ b/src/main/java/konkuk/travelmate/service/RequestService.java
@@ -1,0 +1,41 @@
+package konkuk.travelmate.service;
+
+import konkuk.travelmate.domain.Course;
+import konkuk.travelmate.domain.Request;
+import konkuk.travelmate.domain.RequestState;
+import konkuk.travelmate.domain.User;
+import konkuk.travelmate.form.RequestForm;
+import konkuk.travelmate.repository.CourseRepository;
+import konkuk.travelmate.repository.RequestRepository;
+import konkuk.travelmate.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RequestService {
+
+    private final RequestRepository requestRepository;
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
+    public void requestMatching(Long disabledId, Long courseId, RequestForm requestForm) {
+
+        log.info("RequestService.requestMatching");
+
+        User disabled = userRepository.findById(disabledId).orElseThrow(() -> new RuntimeException("user not found"));
+        Course course = courseRepository.findById(courseId).orElseThrow(() -> new RuntimeException("course not found"));
+
+        requestRepository.save(
+                new Request(
+                        requestForm.getType(),
+                        RequestState.PENDING,
+                        requestForm.getStartTime(),
+                        requestForm.getEndTime(),
+                        disabled,
+                        course));
+
+    }
+}

--- a/src/main/resources/static/css/unwell_deepsearch.css
+++ b/src/main/resources/static/css/unwell_deepsearch.css
@@ -1,0 +1,226 @@
+.form {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.date-time-picker {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+.date-time-input {
+  flex: 1;
+  margin-right: 5px;
+}
+.date-time-input label {
+  display: block;
+  margin-bottom: 5px;
+  height : 50px;
+  line-height: 50px;
+  font-size: 24px;
+}
+
+.date-time-input input {
+  width: 100%;
+  height: 100px;
+  padding: 8px;
+  font-size: 24px;
+  box-sizing: border-box;
+}
+
+.unwell {
+  background-color: #ffffff;
+//  display: flex;
+//  flex-direction: row;
+//  justify-content: center;
+  width: 100%;
+}
+
+.unwell .div {
+  background-color: #ffffff;
+//  width: 393px;
+//  height: 1793px;
+  position: relative;
+width:100%;
+}
+
+.unwell .content1{
+position : relative;
+width:75%;
+margin-left:auto;
+margin-right:auto;
+margin-bottom:150px;
+display:block;
+}
+
+.unwell .content2{
+position : relative;
+width:75%;
+margin-left:auto;
+margin-right:auto;
+margin-bottom:150px;
+display:block;
+}
+
+.unwell .content3{
+position : relative;
+width:75%;
+margin-left:auto;
+margin-right:auto;
+margin-bottom:150px;
+display:block;
+}
+
+.unwell .content4{
+position : relative;
+width:75%;
+margin-left:auto;
+margin-right:auto;
+margin-bottom:150px;
+display:block;
+}
+
+.unwell .content5{
+position : relative;
+width:75%;
+margin-left:auto;
+margin-right:auto;
+margin-bottom:150px;
+display:block;
+}
+
+
+.unwell .cate-wrapper {
+  position: relative;
+//top: 38px;
+//left: 17px;
+  font-family: "Roboto", Helvetica;
+  font-weight: 700;
+  color: #454545;
+  font-size: 48px;
+  text-align: center;
+//  letter-spacing: -0.02px;
+//  line-height: 16.2px;
+//  white-space: nowrap;
+
+display:block;
+margin-top:24px;
+margin-bottom:24px;
+}
+
+.unwell .line-wrapper {
+  position: relative;
+/*
+  top: 59px;
+  width: 360px;
+  height: 2px;
+  left: 17px;
+*/
+display:block;
+object-fit: cover;
+width:100%;
+}
+
+.unwell .img-wrapper {
+  position: relative;
+/*
+  width: 133px;
+  left: 2px;
+  height: 100px;
+  top: 2px;
+*/
+  object-fit: cover;
+display:block;
+margin-left:auto;
+margin-right:auto;
+margin-top:24px;
+margin-bottom:24px;
+width:80%;
+}
+
+.unwell .title-wrapper {
+  position: relative;
+/*
+  width: 210px;
+  height: 97px;
+  top: 3px;
+  left: 5px;
+*/
+  font-family: "Roboto", Helvetica;
+  font-weight: 600;
+  color: #000000;
+  font-size: 30px;
+//  letter-spacing: -0.02px;
+//  line-height: 10.8px;
+display:block;
+text-align:left;
+//  white-space: nowrap;
+margin-top:36px;
+margin-bottom:36px;
+}
+
+.unwell .desc-wrapper {
+  position: relative;
+/*
+  width: 210px;
+  height: 97px;
+  top: 3px;
+  left: 5px;
+*/
+  font-family: "Times New Roman-Regular", Helvetica;
+  font-weight: 400;
+  color: #000000;
+  font-size: 26px;
+//  letter-spacing: -0.02px;
+//  line-height: 10.8px;
+display:block;
+text-align:left;
+//  white-space: nowrap;
+margin-top:36px;
+margin-bottom:72px;
+}
+
+.unwell .submit-wrapper {
+  position: relative;
+width:50%;
+margin-left:auto;
+margin-right:auto;
+margin-top:75px;
+}
+
+.unwell .submit-wrapper-inner {
+  position: relative;
+width:100%;
+margin-left:auto;
+margin-right:auto;
+  height: 60px;
+}
+
+.unwell .submit-wrapper-inner .rect {
+position:absolute;
+width: 100%;
+margin-left:auto;
+margin-right:auto;
+  border-radius: 20px;
+
+  top: 0;
+  left: 0;
+  height: 60px;
+  background-color: #c6c6c6;
+  box-shadow: 0px 8px 8px #00000040;
+  position: absolute;
+}
+
+.unwell .submit-wrapper-inner .text {
+  position: relative;
+//  top: 1px;
+//  left: 7px;
+top:14px;
+  font-family: "Roboto", Helvetica;
+  font-weight: 600;
+  color: #454545;
+  font-size: 36px;
+  text-align: center;
+//  letter-spacing: -0.02px;
+//  line-height: 16.2px;
+//  white-space: nowrap;
+}

--- a/src/main/resources/static/js/unwell_deepsearch.js
+++ b/src/main/resources/static/js/unwell_deepsearch.js
@@ -1,0 +1,101 @@
+// Get all the button elements by their class name
+var buttons = document.querySelectorAll('.request-area');
+
+// Loop through the button elements
+for (var i = 0; i < buttons.length; i++) {
+  // Add an event listener to each button element
+  buttons[i].addEventListener('click', function(event) {
+    // Prevent the default behavior of the button element
+    event.preventDefault();
+    // Get the parent element of the button element
+    var parent = event.target.parentElement;
+
+    // While the parent element is not a form element
+    while (parent.tagName !== 'FORM') {
+      // Get the parent element of the parent element
+      parent = parent.parentElement;
+    }
+
+// startDate와 startTime을 합쳐서 startDatetime에 저장
+var startDates = document.querySelectorAll(".startDate"); // startDate 클래스를 가진 모든 input 태그를 배열로 가져오기
+var startTimes = document.querySelectorAll(".startTime"); // startTime 클래스를 가진 모든 input 태그를 배열로 가져오기
+var startDatetimes = document.querySelectorAll(".startDatetime"); // startDatetime 클래스를 가진 모든 input 태그를 배열로 가져오기
+for (var i = 0; i < startDates.length; i++) { // 배열의 길이만큼 반복하기
+  var startDate = startDates[i].value; // i번째 input 태그의 value 값 가져오기
+  var startTime = startTimes[i].value; // i번째 input 태그의 value 값 가져오기
+  var startDatetime = startDate + " " + startTime + ":00"; // YYYY-MM-DD HH:MM:SS 형식의 문자열 만들기
+  startDatetimes[i].value = startDatetime; // i번째 input 태그에 startDatetime 변수 넣기
+}
+
+// endDate와 endTime을 합쳐서 endDatetime에 저장
+var endDates = document.querySelectorAll(".endDate"); // endDate 클래스를 가진 모든 input 태그를 배열로 가져오기
+var endTimes = document.querySelectorAll(".endTime"); // endTime 클래스를 가진 모든 input 태그를 배열로 가져오기
+var endDatetimes = document.querySelectorAll(".endDatetime"); // endDatetime 클래스를 가진 모든 input 태그를 배열로 가져오기
+for (var i = 0; i < endDates.length; i++) { // 배열의 길이만큼 반복하기
+  var endDate = endDates[i].value; // i번째 input 태그의 value 값 가져오기
+  var endTime = endTimes[i].value; // i번째 input 태그의 value 값 가져오기
+  var endDatetime = endDate + " " + endTime + ":00"; // YYYY-MM-DD HH:MM:SS 형식의 문자열 만들기
+  endDatetimes[i].value = endDatetime; // i번째 input 태그에 endDatetime 변수 넣기
+}
+
+
+    // Submit the parent form element
+    console.log(parent);
+    parent.submit()
+    console.log("부모");
+    console.log(parent);
+    alert("HELP Requested");
+    //location.href="http://localhost:8080/course";
+
+  });
+}
+
+
+
+
+// SET input date/time to NOW
+// 현재 날짜와 시간을 가져옵니다.
+var today = new Date();
+
+// 현재 날짜를 yyyy-mm-dd 형식으로 변환합니다.
+var date = today.getFullYear() + '-' + (today.getMonth() + 1).toString().padStart(2, '0') + '-' + today.getDate().toString().padStart(2, '0');
+
+// 현재 시간을 hh:mm 형식으로 변환합니다.
+var time = today.getHours().toString().padStart(2, '0') + ':' + today.getMinutes().toString().padStart(2, '0');
+
+// HTML 문서에서 모든 input 요소를 선택합니다.
+var inputs = document.querySelectorAll('input');
+
+// 각 input 요소에 대해 반복합니다.
+for (var i = 0; i < inputs.length; i++) {
+  // input 요소의 type과 id를 확인합니다.
+  var type = inputs[i].getAttribute('type');
+  var cla = inputs[i].getAttribute('class');
+
+
+  if (type === 'date' && cla === 'startDate') {
+    // input 요소의 value를 현재 날짜로 설정합니다.
+    inputs[i].value = date;
+  }
+
+  if (type === 'time' && cla === 'startTime') {
+    // input 요소의 value를 현재 시간으로 설정합니다.
+    inputs[i].value = time;
+  }
+
+  if (type === 'date' && cla === 'endDate') {
+	var newDay = new Date();
+        newDay.setDate(newDay.getDate() + 1);
+
+	// 현재 날짜를 yyyy-mm-dd 형식으로 변환합니다.
+	var newDate = newDay.getFullYear() + '-' + (newDay.getMonth() + 1).toString().padStart(2, '0') + '-' + 	newDay.getDate().toString().padStart(2, '0');
+
+    // input 요소의 value를 현재 날짜로 설정합니다.
+    inputs[i].value = newDate;
+  }
+
+  if (type === 'time' && cla === 'endTime') {
+    // input 요소의 value를 현재 시간으로 설정합니다.
+    inputs[i].value = time;
+  }
+}

--- a/src/main/resources/templates/unwell_deepsearch.html
+++ b/src/main/resources/templates/unwell_deepsearch.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="/css/globals.css" />
+    <link rel="stylesheet" href="/css/unwell_deepsearch.css" />
+    <link rel="stylesheet" href="/css/unwell_tabbar.css" />
+</head>
+<body>
+<div class="unwell">
+    <div class="div">
+
+        <!-- #1 전체 설명, 1:1 -->
+        <div class="content1">
+            <div class="cate-wrapper">Course</div>
+            <img class="line-wrapper" src="/img/unwell/line-7.svg" />
+
+            <!-- @TODO HERE -->
+            <!-- IMG -->
+            <img class="img-wrapper" src="/img/unwell/image-8.png" />
+            <!-- TITLE -->
+            <div class="title-wrapper">
+                Konkuk Univ
+            </div>
+            <!-- DESC -->
+            <div class="desc-wrapper">
+                Konkuk Univ., located in Seoul<br>
+                They think student is just a money.
+            </div>
+            <!-- @TODO HERE -->
+
+            <form action="http://localhost:8080/users/1/courses/1/request" method="post" class="form">
+                <input type="hidden" class="type" name="type" value="ALL" />
+                <input type="hidden" class="uId" name="uId" value=1111 />
+                <input type="hidden" class="startDatetime" name="startDatetime" />
+                <input type="hidden" class="endDatetime" name="endDatetime" />
+                <input type="date" class="startDate" name="startDate"/>
+                <input type="time" class="startTime" name="startTime"/>
+                <input type="date" class="endDate" name="endDate"/>
+                <input type="time" class="endTime" name="endTime"/>
+                <div class="submit-wrapper"><div class="submit-wrapper-inner request-area">
+                    <div class="rect"></div><div class="text">Request HELP</div>
+                </div></div>
+            </form>
+        </div>
+        <!-- #1 전체 설명, 1:1 -->
+
+        <!-- #2 이동수단, 1:N -->
+        <div class="content2">
+            <div class="cate-wrapper">Transportation</div>
+            <img class="line-wrapper" src="/img/unwell/line-7.svg" />
+
+            <!-- @TODO HERE -->
+            <!-- IMG #1 -->
+            <img class="img-wrapper" src="/img/unwell/image-10.png" />
+            <!-- TITLE #1 -->
+            <div class="title-wrapper">
+                Konkuk Univ Cow (mascot KU)
+            </div>
+            <!-- DESC #1 -->
+            <div class="desc-wrapper">
+                You can ride cow in campus.<br>
+                Bull is also meaning "떡상" in Korea.
+            </div>
+
+            <!-- IMG #2 -->
+            <img class="img-wrapper" src="/img/unwell/image-11.png" />
+            <!-- TITLE #2 -->
+            <div class="title-wrapper">
+                Helicopter Site
+            </div>
+            <!-- DESC #2 -->
+            <div class="desc-wrapper">
+                You can also use Helipcopter in campus.<br>
+                It costs about KRW 100,000.<br>
+                Konkuk is money-making company, not a university.
+            </div>
+            <!-- @TODO HERE -->
+
+            <form action="http://localhost:8080/users/{userId}/courses/{courseId}/request" method="post" class="form">
+                <input type="hidden" class="type" name="type" value="TRANSPORTATION"/>
+                <input type="hidden" class="uId" name="uId" value=2222 />
+                <input type="hidden" class="startDatetime" name="startDatetime" />
+                <input type="hidden" class="endDatetime" name="endDatetime" />
+                <input type="date" class="startDate" name="startDate"/>
+                <input type="time" class="startTime" name="startTime"/>
+                <input type="date" class="endDate" name="endDate"/>
+                <input type="time" class="endTime" name="endTime"/>
+                <div class="submit-wrapper"><div class="submit-wrapper-inner request-area">
+                    <div class="rect"></div><div class="text">Request HELP</div>
+                </div></div>
+            </form>
+        </div>
+        <!-- #2 이동수단, 1:N -->
+
+        <!-- #3 숙박, 1:N -->
+        <div class="content3">
+            <div class="cate-wrapper">Lodgment</div>
+            <img class="line-wrapper" src="/img/unwell/line-7.svg" />
+
+            <!-- @TODO HERE -->
+            <!-- IMG #1 -->
+            <img class="img-wrapper" src="/img/unwell/image-10.png" />
+            <!-- TITLE #1 -->
+            <div class="title-wrapper">
+                Konkuk Univ Cow (mascot KU)
+            </div>
+            <!-- DESC #1 -->
+            <div class="desc-wrapper">
+                You can ride cow in campus.<br>
+                Bull is also meaning "떡상" in Korea.
+            </div>
+
+            <!-- IMG #2 -->
+            <img class="img-wrapper" src="/img/unwell/image-11.png" />
+            <!-- TITLE #2 -->
+            <div class="title-wrapper">
+                Helicopter Site
+            </div>
+            <!-- DESC #2 -->
+            <div class="desc-wrapper">
+                You can also use Helipcopter in campus.<br>
+                It costs about KRW 100,000.<br>
+                Konkuk is money-making company, not a university.
+            </div>
+            <!-- @TODO HERE -->
+
+            <form action="http://localhost:8080/users/{userId}/courses/{courseId}/request" method="post" class="form">
+                <input type="hidden" class="type" name="type" value="LODGING" />
+                <input type="hidden" class="uId" name="uId" value=3333 />
+                <input type="hidden" class="startDatetime" name="startDatetime" />
+                <input type="hidden" class="endDatetime" name="endDatetime" />
+                <input type="date" class="startDate" name="startDate"/>
+                <input type="time" class="startTime" name="startTime"/>
+                <input type="date" class="endDate" name="endDate"/>
+                <input type="time" class="endTime" name="endTime"/>
+                <div class="submit-wrapper"><div class="submit-wrapper-inner request-area">
+                    <div class="rect"></div><div class="text">Request HELP</div>
+                </div></div>
+            </form>
+        </div>
+        <!-- #3 숙박, 1:N -->
+
+        <!-- #4 식당, 1:N -->
+        <div class="content4">
+            <div class="cate-wrapper">Restaurant</div>
+            <img class="line-wrapper" src="/img/unwell/line-7.svg" />
+
+            <!-- @TODO HERE -->
+            <!-- IMG #1 -->
+            <img class="img-wrapper" src="/img/unwell/image-10.png" />
+            <!-- TITLE #1 -->
+            <div class="title-wrapper">
+                Konkuk Univ Cow (mascot KU)
+            </div>
+            <!-- DESC #1 -->
+            <div class="desc-wrapper">
+                You can ride cow in campus.<br>
+                Bull is also meaning "떡상" in Korea.
+            </div>
+
+            <!-- IMG #2 -->
+            <img class="img-wrapper" src="/img/unwell/image-11.png" />
+            <!-- TITLE #2 -->
+            <div class="title-wrapper">
+                Helicopter Site
+            </div>
+            <!-- DESC #2 -->
+            <div class="desc-wrapper">
+                You can also use Helipcopter in campus.<br>
+                It costs about KRW 100,000.<br>
+                Konkuk is money-making company, not a university.
+            </div>
+            <!-- @TODO HERE -->
+
+            <form action="http://localhost:8080/users/{userId}/courses/{courseId}/request" method="post" class="form">
+                <input type="hidden" class="type" name="type" value="RESTAURANT" />
+                <input type="hidden" class="uId" name="uId" value=4444 />
+                <input type="hidden" class="startDatetime" name="startDatetime" />
+                <input type="hidden" class="endDatetime" name="endDatetime" />
+                <input type="date" class="startDate" name="startDate"/>
+                <input type="time" class="startTime" name="startTime"/>
+                <input type="date" class="endDate" name="endDate"/>
+                <input type="time" class="endTime" name="endTime"/>
+                <div class="submit-wrapper"><div class="submit-wrapper-inner request-area">
+                    <div class="rect"></div><div class="text">Request HELP</div>
+                </div></div>
+            </form>
+        </div>
+        <!-- #4 식당, 1:N -->
+
+        <!-- #5 관광지, 1:N -->
+        <div class="content5">
+            <div class="cate-wrapper">Travel Site</div>
+            <img class="line-wrapper" src="/img/unwell/line-7.svg" />
+
+            <!-- @TODO HERE -->
+            <!-- IMG #1 -->
+            <img class="img-wrapper" src="/img/unwell/image-10.png" />
+            <!-- TITLE #1 -->
+            <div class="title-wrapper">
+                Konkuk Univ Cow (mascot KU)
+            </div>
+            <!-- DESC #1 -->
+            <div class="desc-wrapper">
+                You can ride cow in campus.<br>
+                Bull is also meaning "떡상" in Korea.
+            </div>
+
+            <!-- IMG #2 -->
+            <img class="img-wrapper" src="/img/unwell/image-11.png" />
+            <!-- TITLE #2 -->
+            <div class="title-wrapper">
+                Helicopter Site
+            </div>
+            <!-- DESC #2 -->
+            <div class="desc-wrapper">
+                You can also use Helipcopter in campus.<br>
+                It costs about KRW 100,000.<br>
+                Konkuk is money-making company, not a university.
+            </div>
+            <!-- @TODO HERE -->
+
+            <form action="http://localhost:8080/users/{userId}/courses/{courseId}/request" method="post" class="form">
+                <input type="hidden" class="type" name="type" value="PLACE" />
+                <input type="hidden" class="uId" name="uId" value=5555 />
+                <input type="hidden" class="startDatetime" name="startDatetime" />
+                <input type="hidden" class="endDatetime" name="endDatetime" />
+                <input type="date" class="startDate" name="startDate"/>
+                <input type="time" class="startTime" name="startTime"/>
+                <input type="date" class="endDate" name="endDate"/>
+                <input type="time" class="endTime" name="endTime"/>
+                <div class="submit-wrapper"><div class="submit-wrapper-inner request-area">
+                    <div class="rect"></div><div class="text">Request HELP</div>
+                </div></div>
+            </form>
+        </div>
+        <!-- #5 관광지, 1:N -->
+
+        <br><br><br><br>
+
+        <div class="menubar-sudong">
+            <div class="nav-item-sudong" onclick='location.href="unwell_search.html"'>
+                <img class="img-sudong" src="/img/unwell/find.svg" />
+                <div class="text-wrapper-sudong">Explore</div>
+            </div>
+            <div class="nav-item-sudong" onclick='location.href="unwell_matching.html"'>
+                <img class="img-sudong" src="/img/unwell/table.svg" />
+                <div class="text-wrapper-sudong">Result</div>
+            </div>
+            <div class="nav-item-sudong" onclick='location.href="unwell_personalize.html"'>
+                <img class="img-sudong" src="/img/unwell/recommend.svg" />
+                <div class="text-wrapper-sudong">Recommend</div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<script src="/js/unwell_deepsearch.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
## 🗒️ Description
`GET`: /users/{userId}/courses/{courseId}
- 코스 상세 페이지 랜더링

`POST`: /users/{userId}/courses/{courseId}/request
- Request 테이블에 저장

## 📌 TODO
RequestForm 요청 처리 로직 수정
- `@RequestParam` -> `@ModelAttribute`, `타임리프`

## 🔥 Trouble Shooting
`RequestController`에서 insert시`Proxy` 문제 해결
- `@EntityGraph` 적용 -> `User`, `Course` 객체 조회 시 지연 로딩 적용 X, join으로 한 번에 조회