### PR TITLE
fix: 인증/인가 관련 버그 및 매칭 조회 쿼리 수정

### DIFF
--- a/src/main/java/konkuk/travelmate/config/SecurityConfig.java
+++ b/src/main/java/konkuk/travelmate/config/SecurityConfig.java
@@ -3,10 +3,12 @@ package konkuk.travelmate.config;
 import konkuk.travelmate.security.GoogleOAuthProperties;
 import konkuk.travelmate.security.OAuth2MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.oauth2.client.CommonOAuth2Provider;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -28,7 +30,7 @@ public class SecurityConfig {
         http
                 .csrf(CsrfConfigurer::disable)
                 .oauth2Login(o -> o
-                        .loginPage("/login/")
+                        .loginPage("/login")
                         .defaultSuccessUrl("/login/gateway")
                         .userInfoEndpoint(info -> info
                                 .userService(oAuth2MemberService)
@@ -39,13 +41,13 @@ public class SecurityConfig {
 
 
                 .authorizeHttpRequests(o->o
-                        .requestMatchers("/test").authenticated()
-                        .anyRequest().permitAll()
+                        .requestMatchers("/login/**").permitAll()
+                        .requestMatchers("/css/**", "/js/**", "/img/**").permitAll()
+                        .anyRequest().authenticated()
                 )
                 ;
         return http.build();
     }
-
 
     private ClientRegistration googleOauthClientRegistration() {
 

--- a/src/main/java/konkuk/travelmate/repository/MatchingRepository.java
+++ b/src/main/java/konkuk/travelmate/repository/MatchingRepository.java
@@ -14,6 +14,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
             "WHERE d.role = 0 AND r.requestId IN ( " +
             "SELECT m.request.requestId " +
             "FROM Matching m JOIN m.volunteer v " +
-            "WHERE v.email = :email)")
+            "WHERE v.email = :email AND m.request.state <> 2)")
     List<GetVolunteerMatchingResponse> findVolunteerMatchingResultsByEmail(@Param("email") String email);
 }

--- a/src/test/java/konkuk/travelmate/service/MatchingServiceTest.java
+++ b/src/test/java/konkuk/travelmate/service/MatchingServiceTest.java
@@ -1,0 +1,158 @@
+package konkuk.travelmate.service;
+
+import konkuk.travelmate.config.SecurityConfig;
+import konkuk.travelmate.domain.*;
+import konkuk.travelmate.dto.response.GetVolunteerMatchingResponse;
+import konkuk.travelmate.repository.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import static konkuk.travelmate.domain.RequestState.*;
+import static konkuk.travelmate.domain.TravelType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class MatchingServiceTest {
+
+    @Autowired private MatchingService matchingService;
+    @Autowired private MatchingRepository matchingRepository;
+    @Autowired private HealthRepository healthRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private CourseRepository courseRepository;
+    @Autowired private RequestRepository requestRepository;
+    @MockBean private SecurityConfig securityConfig;
+
+    @AfterEach
+    void tearDown() {
+        matchingRepository.deleteAll();
+        requestRepository.deleteAll();
+        courseRepository.deleteAll();
+        userRepository.deleteAll();
+        healthRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("봉사자의 매칭 결과 상태로 WAIT, SUCCESS 가 조회된다.")
+    void showMatchResults() {
+        //given
+        Health health = createHealth(0, 0, 0, 0, 0, 0, 0);
+        Health health2 = createHealth(0, 0, 0, 0, 0, 0, 0);
+        Health health3 = createHealth(0, 0, 0, 0, 0, 0, 0);
+        healthRepository.saveAll(List.of(health, health2, health3));
+
+        User disabled = createUser("d1", "d1@gmail.com", "d1", "01012341234", Role.DISABLED, health);
+        User volunteer = createUser( "v1", "v1@gmail.com", "v1", "01012341234", Role.VOLUNTEER, null);
+        userRepository.saveAll(List.of(disabled, volunteer));
+
+        Course course = createCourse("서울여행", "서울", "서울여행123", "asdf@ewaf.com", health2);
+        Course course2 = createCourse("부산여행", "부산", "부산여행123", "asdf@ewaf.com", health3);
+        courseRepository.saveAll(List.of(course, course2));
+
+        Request request = createRequest(ALL, WAIT, Timestamp.valueOf("2024-02-22 14:54:00"),
+                Timestamp.valueOf("2024-02-22 14:54:00"), disabled, course);
+        Request request2 = createRequest(LODGING, SUCCESS, Timestamp.valueOf("2024-02-22 14:54:00"),
+                Timestamp.valueOf("2024-02-22 14:54:00"), disabled, course);
+        Request request3 = createRequest(LODGING, FAIL, Timestamp.valueOf("2024-02-22 14:54:00"),
+                Timestamp.valueOf("2024-02-22 14:54:00"), disabled, course);
+        requestRepository.saveAll(List.of(request, request2, request3));
+
+        Matching matching = Matching.createNullRatingMatching(volunteer, request);
+        Matching matching2 = Matching.createNullRatingMatching(volunteer, request2);
+        matchingRepository.saveAll(List.of(matching, matching2));
+
+        //when
+        List<GetVolunteerMatchingResponse> matchings = matchingService.getMatchResults("v1@gmail.com");
+
+        //then
+        assertThat(matchings).hasSize(2)
+                .extracting("disabledName", "startTime", "endTime", "type", "state", "disabledPhoneName", "disabledEmail")
+                .containsExactly(
+                        tuple("d1", Timestamp.valueOf("2024-02-22 14:54:00"), Timestamp.valueOf("2024-02-22 14:54:00"),
+                                ALL, WAIT, "01012341234", "d1@gmail.com"),
+                        tuple("d1", Timestamp.valueOf("2024-02-22 14:54:00"), Timestamp.valueOf("2024-02-22 14:54:00"),
+                                LODGING, SUCCESS, "01012341234", "d1@gmail.com")
+                );
+    }
+
+    @DisplayName("봉사자의 매칭 결과 상태로 FAIL은 조회되지 않는다.")
+    @Test
+    void test() {
+        //given
+        Health health = createHealth(0, 0, 0, 0, 0, 0, 0);
+        Health health2 = createHealth(0, 0, 0, 0, 0, 0, 0);
+        healthRepository.saveAll(List.of(health, health2));
+
+        User disabled = createUser("d1", "d1@gmail.com", "d1", "01012341234", Role.DISABLED, health);
+        User volunteer = createUser( "v1", "v1@gmail.com", "v1", "01012341234", Role.VOLUNTEER, null);
+        userRepository.saveAll(List.of(disabled, volunteer));
+
+        Course course = createCourse("서울여행", "서울", "서울여행123", "asdf@ewaf.com", health2);
+        courseRepository.save(course);
+
+        Request request3 = createRequest(LODGING, FAIL, Timestamp.valueOf("2024-02-22 14:54:00"),
+                Timestamp.valueOf("2024-02-22 14:54:00"), disabled, course);
+        requestRepository.save(request3);
+
+        Matching matching = Matching.createNullRatingMatching(volunteer, request3);
+        matchingRepository.save(matching);
+
+        //when
+        List<GetVolunteerMatchingResponse> matchings = matchingService.getMatchResults("v1@gmail.com");
+
+        //then
+        assertThat(matchings).hasSize(0);
+    }
+
+    private Health createHealth(int walk, int see, int talk, int listen, int depression, int bipolarDisorder, int iq) {
+        return Health.builder()
+                .walk(walk)
+                .see(see)
+                .talk(talk)
+                .listen(listen)
+                .depression(depression)
+                .bipolarDisorder(bipolarDisorder)
+                .iq(iq)
+                .build();
+    }
+
+    private User createUser(String name, String email, String password, String phoneNum, Role role, Health health) {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .password(password)
+                .phoneNum(phoneNum)
+                .role(role)
+                .health(health)
+                .build();
+    }
+
+    private Course createCourse(String name, String description, String region, String imageUrl, Health health) {
+        return Course.builder()
+                .name(name)
+                .description(description)
+                .region(region)
+                .imageUrl(imageUrl)
+                .health(health)
+                .build();
+    }
+
+    private Request createRequest(TravelType type, RequestState state, Timestamp startTime, Timestamp endTime, User disabled, Course course) {
+        return Request.builder()
+                .type(type)
+                .state(state)
+                .startTime(startTime)
+                .endTime(endTime)
+                .disabled(disabled)
+                .course(course)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🗒️ Description
- 인증/인가 관련 버그 수정 
- 매칭 조회 결과에 FAIL이 포함되지 않도록 쿼리를 수정

- 매칭 서비스 테스트 코드 추가

## 🔥 Trouble Shooting
- Security Config에서 `.loginPage`의 링크가 `/login/`으로 되어 있어 마지막 / 를 삭제하여 버그를 수정하였습니다.
- `authorizeHttpRequests`의 `.requestMatchers`에 `/login`이 포함되어 있지 않아 로그인 페이지를 무한 리디렉션 하고 있던 버그를 해결하였습니다. 추가로 css, js, img 파일도 허용하여 화면이 정상적으로 랜더링 되도록 하였습니다.